### PR TITLE
Add Frida Kahlo Cumulative Project Notebook

### DIFF
--- a/4_python_fundamentals_for_data_science/frida_kahlo_cumulative_project/frida_project.ipynb
+++ b/4_python_fundamentals_for_data_science/frida_kahlo_cumulative_project/frida_project.ipynb
@@ -1,0 +1,280 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Frida Kahlo Exhibition\n",
+    "\n",
+    "You've been hired to work on a retrospective of Frida Kahlo's work at a major museum. Your job is to put together the audio tour, but in order to do that you need to create a list of each painting featured in the exhibit, the date it was painted, and its spot in the tour. \n",
+    "\n",
+    "Use your knowledge of Python lists to create a master list of each painting, its date, and its audio tour ID. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 1\n",
+    "First, create a list called `paintings` and add the following titles to it:\n",
+    "\n",
+    "`The Two Fridas, My Dress Hangs Here, Tree of Hope, Self Portrait With Monkeys`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "collapsed": true,
+    "ExecuteTime": {
+     "end_time": "2024-08-04T23:27:23.457603Z",
+     "start_time": "2024-08-04T23:27:23.455178Z"
+    }
+   },
+   "source": "paintings = [\"The Two Fridas\", \"My Dress Hangs Here\", \"Tree of Hope\", \"Self Portrait With Monkeys\"]",
+   "outputs": [],
+   "execution_count": 1
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 2\n",
+    "\n",
+    "Next, create a second list called `dates` and give it the following values:\n",
+    "`1939, 1933, 1946, 1940`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "collapsed": true,
+    "ExecuteTime": {
+     "end_time": "2024-08-04T23:27:23.464412Z",
+     "start_time": "2024-08-04T23:27:23.462798Z"
+    }
+   },
+   "source": "dates = [1939, 1933, 1946, 1940]",
+   "outputs": [],
+   "execution_count": 2
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 3 \n",
+    "It doesn't do much good to have the paintings without their dates, and vice versa. \n",
+    "Zip together the two lists so that each painting is paired with its date and resave it to the `paintings` variable. Make sure to convert the zipped object into a list using the `list()` function. Print the results to the terminal to check your work. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "collapsed": true,
+    "ExecuteTime": {
+     "end_time": "2024-08-04T23:27:23.467453Z",
+     "start_time": "2024-08-04T23:27:23.465526Z"
+    }
+   },
+   "source": [
+    "paintings = list(zip(paintings, dates))\n",
+    "print(paintings)"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[('The Two Fridas', 1939), ('My Dress Hangs Here', 1933), ('Tree of Hope', 1946), ('Self Portrait With Monkeys', 1940)]\n"
+     ]
+    }
+   ],
+   "execution_count": 3
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 4\n",
+    "There were some last minute additions to the show that we need to add to our list. Append the following paintings to our `paintings` list then re-print to check they were added correctly:\n",
+    "- 'The Broken Column', 1944\n",
+    "- 'The Wounded Deer', 1946\n",
+    "- 'Me and My Doll', 1937\n",
+    "\n",
+    "Hint: Make sure to append each painting individually and that you're appending them as tuples, not lists. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "collapsed": true,
+    "ExecuteTime": {
+     "end_time": "2024-08-04T23:27:23.470167Z",
+     "start_time": "2024-08-04T23:27:23.468163Z"
+    }
+   },
+   "source": [
+    "additions = [\n",
+    "    (\"The Broken Column\", 1944),\n",
+    "    (\"The Wounded Deer\", 1946),\n",
+    "    (\"Me and My Doll\", 1937)\n",
+    "]\n",
+    "\n",
+    "for painting in additions:\n",
+    "    paintings.append(painting)\n",
+    "    \n",
+    "print(paintings)"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[('The Two Fridas', 1939), ('My Dress Hangs Here', 1933), ('Tree of Hope', 1946), ('Self Portrait With Monkeys', 1940), ('The Broken Column', 1944), ('The Wounded Deer', 1946), ('Me and My Doll', 1937)]\n"
+     ]
+    }
+   ],
+   "execution_count": 4
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 5\n",
+    "Since each of these paintings is going to be in the audio tour, they each need a unique identification number.\n",
+    "But before we assign them a number, we first need to check how many paintings there are in total.\n",
+    "\n",
+    "Find the length of the `paintings` list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "collapsed": true,
+    "ExecuteTime": {
+     "end_time": "2024-08-04T23:27:23.472930Z",
+     "start_time": "2024-08-04T23:27:23.471355Z"
+    }
+   },
+   "source": "print(len(paintings))",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7\n"
+     ]
+    }
+   ],
+   "execution_count": 5
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 6\n",
+    "Use the `range` method to generate a list of identification numbers that starts at 1 and is equal in length to our list of items. \n",
+    "Save the list to the variable `audio_tour_number` and check your work by printing the list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "collapsed": true,
+    "ExecuteTime": {
+     "end_time": "2024-08-04T23:27:23.474974Z",
+     "start_time": "2024-08-04T23:27:23.473557Z"
+    }
+   },
+   "source": [
+    "audio_tour_number = list(range(1, len(paintings) + 1))\n",
+    "\n",
+    "print(audio_tour_number)"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[1, 2, 3, 4, 5, 6, 7]\n"
+     ]
+    }
+   ],
+   "execution_count": 6
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 7 \n",
+    "\n",
+    "We're finally read to create our master list. \n",
+    "Zip the `audio_tour_number` list to the `paintings` list and save it as `master_list`.\n",
+    "\n",
+    "Hint: Make sure to convert the zipped object into a list using the `list()` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "collapsed": true,
+    "ExecuteTime": {
+     "end_time": "2024-08-04T23:27:23.477199Z",
+     "start_time": "2024-08-04T23:27:23.475618Z"
+    }
+   },
+   "source": "master_list = list(zip(audio_tour_number, paintings))",
+   "outputs": [],
+   "execution_count": 7
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task 8 \n",
+    "Print the `master_list` to the terminal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "collapsed": true,
+    "ExecuteTime": {
+     "end_time": "2024-08-04T23:27:23.479431Z",
+     "start_time": "2024-08-04T23:27:23.477789Z"
+    }
+   },
+   "source": "print(master_list)",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[(1, ('The Two Fridas', 1939)), (2, ('My Dress Hangs Here', 1933)), (3, ('Tree of Hope', 1946)), (4, ('Self Portrait With Monkeys', 1940)), (5, ('The Broken Column', 1944)), (6, ('The Wounded Deer', 1946)), (7, ('Me and My Doll', 1937))]\n"
+     ]
+    }
+   ],
+   "execution_count": 8
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
- Introduced new Jupyter Notebook file `frida_project.ipynb` for the Frida Kahlo exhibition.
- Added markdown cells detailing tasks for creating a master list of paintings, dates, and audio tour IDs.
- Implemented Python code cells to:
  - Initialize lists for painting titles and dates.
  - Zip lists together to pair each painting with its date.
  - Append additional paintings to the list.
  - Calculate the total number of paintings and generate unique identification numbers.
  - Create and print a master list combining painting info and IDs.